### PR TITLE
Added support for SVGs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # LESS Long Shadow
 
-This [LESS](http://lesscss.org/) loop mixins generates trendy flat long shadow with any angle for inline text, font icons and block elements. Looks best if wrapped by square `overflow: hidden;` container with _bold_ padding and rounded corners. Dont forget about good contrast color palette. Enjoy!
+This [LESS](http://lesscss.org/) loop mixins generates trendy flat long shadow with any angle for inline text, font icons, block elements and SVGs. Looks best if wrapped by square `overflow: hidden;` container with _bold_ padding and rounded corners. Dont forget about good contrast color palette. Enjoy!
 
 * Source: [GitHub](https://github.com/zensimilia/less-long-shadow)
 * Demo: [CodePen](http://codepen.io/zensimilia/full/XbVgNx/)
@@ -20,6 +20,7 @@ This [LESS](http://lesscss.org/) loop mixins generates trendy flat long shadow w
 .someClass {
     #long-shadow.inline(@color, @angle, @size); // For text or icon
     #long-shadow.block(@color, @angle, @size, @prefix); // For container
+    #long-shadow.svg(@color, @angle, @size, @prefix); // For SVG
 }
 ```
 
@@ -31,7 +32,7 @@ This [LESS](http://lesscss.org/) loop mixins generates trendy flat long shadow w
   * Default `45`.
 * __@size__ that shadow length would be:
   * Default `10`.
-* __@prefix__ param define the use of CSS _browser-prefixes_ for `box-shadow` rule:
+* __@prefix__ param define the use of CSS _browser-prefixes_ for `box-shadow` or `filter` rule:
   * `0` : _false_
   * `1` : _true_ Default
 
@@ -47,6 +48,9 @@ Have a bug or a feature request? [Please open a new issue](https://github.com/ze
 - [x] Add ability to specify an angle of shadow.
 
 ## Changelog
+
+__2.1.0__
+* Add support for shadows on SVG.
 
 __2.0.0__
 * __INCOMPATIBLE CHANGES!__ Add _namespace_ and rename mixins.

--- a/less/long-shadow.less
+++ b/less/long-shadow.less
@@ -48,4 +48,25 @@
         .loopPrefix(@alltogether, @size - 1);
         .block(@color, @angle, @size - 1, @prefix, @flag + 1, @close);
     }
+    
+    .svg(@color: @CCCCCC, @angle: 45, @size: 10, @prefix: 1, @flag: 1, @temp: "") when (@size > 0) {
+        @angle360: @angle * (pi() / 180);
+        @x: round(@flag * cos(@angle360));
+        @y: round(@flag * sin(@angle360));
+        @shadow: ~"@{x}px @{y}px 0px @{color}";
+        @close: ~"@{shadow}) drop-shadow(@{temp}";
+        @alltogether: ~"drop-shadow(@{close} 0px 0px 0px @{color})";
+    
+        .loop(@string, @index) when (@index < 1) {
+            filter: @string;
+        }
+    
+        .loopPrefix(@string, @index) when (@index < 1) and (@prefix > 0) {
+            -webkit-filter: @string;
+        }
+    
+        .loop(@alltogether, @size - 1);
+        .loopPrefix(@alltogether, @size - 1);
+        .svg(@color, @angle, @size - 1, @prefix, @flag + 1, @close);
+    }
 }


### PR DESCRIPTION
I wanted to use this mixin for an SVG, but neither `box-shadow` or `text-shadow` work on an SVG. So I added another option using the `filter: drop-shadow();` CSS property, which is [mostly supported](http://caniuse.com/#feat=css-filters).
